### PR TITLE
Python 3 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 build/
 dist/
 grin.egg-info/
+
+__pycache__/
+*.py[cod]
+.tox/

--- a/tests/test_grep.py
+++ b/tests/test_grep.py
@@ -4,7 +4,11 @@ r'''
 Set up
 
     >>> import grin
-    >>> from cStringIO import StringIO
+    >>> try:
+    ...     from cStringIO import StringIO
+    ... except ImportError:
+    ...     from io import StringIO
+    ...
     >>> import re
     >>> 
     >>> all_foo = """\

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,7 @@
+[tox]
+envlist=py26, py27, py34, py35
+[testenv]
+usedevelop=True
+deps=nose
+commands=nosetests
+


### PR DESCRIPTION
This PR adds Python 3 support to Grin. Perhaps the most non-trivial aspect is that under Python 3 this assumes that strings are encoded as UTF-8. This may not be what the user always wants, and it makes Grin under Python 3 a little more fragile (e.g. grinning a file with mixed ASCII/binary data is problematic). 
